### PR TITLE
run_time_max should be in seconds

### DIFF
--- a/pysqa/queueadapter.py
+++ b/pysqa/queueadapter.py
@@ -105,15 +105,16 @@ class QueueAdapter(object):
         command=None,
     ):
         """
+        Submits command to the given queue.
 
         Args:
-            queue (str/None):
-            job_name (str/None):
-            working_directory (str/None):
-            cores (int/None):
-            memory_max (int/None):
-            run_time_max (int/None):
-            command (str/None):
+            queue (str/None):  Name of the queue to submit to, must be one of the names configured for this adapter
+            job_name (str/None):  Name of the job for the underlying queuing system
+            working_directory (str/None):  Directory to run the job in
+            cores (int/None):  Number of hardware threads requested
+            memory_max (int/None):  Amount of memory requested per hardware thread in GiB
+            run_time_max (int/None):  Maximum runtime in seconds
+            command (str/None):  shell command to run in the job
 
         Returns:
             int:

--- a/pysqa/queueadapter.py
+++ b/pysqa/queueadapter.py
@@ -112,7 +112,7 @@ class QueueAdapter(object):
             job_name (str/None):  Name of the job for the underlying queuing system
             working_directory (str/None):  Directory to run the job in
             cores (int/None):  Number of hardware threads requested
-            memory_max (int/None):  Amount of memory requested per hardware thread in GiB
+            memory_max (int/None):  Amount of memory requested per node in GB
             run_time_max (int/None):  Maximum runtime in seconds
             command (str/None):  shell command to run in the job
 

--- a/tests/config/slurm/slurm.sh
+++ b/tests/config/slurm/slurm.sh
@@ -5,7 +5,7 @@
 #SBATCH --get-user-env=L
 #SBATCH --partition=slurm
 {%- if run_time_max %}
-#SBATCH --time={{run_time_max}}
+#SBATCH --time={{run_time_max // 60}}
 {%- endif %}
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}


### PR DESCRIPTION
SLURM wants the runtime to be in minutes, but callers give it in seconds

Untested, but should work as per [docs](https://jinja.palletsprojects.com/en/2.11.x/templates/#math).