### PR TITLE
Avoid 0 in time flag

### DIFF
--- a/tests/config/slurm/slurm.sh
+++ b/tests/config/slurm/slurm.sh
@@ -5,7 +5,7 @@
 #SBATCH --get-user-env=L
 #SBATCH --partition=slurm
 {%- if run_time_max %}
-#SBATCH --time={{max(1, run_time_max // 60)}}
+#SBATCH --time={{ [1, run_time_max // 60]|max }}
 {%- endif %}
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}

--- a/tests/config/slurm/slurm.sh
+++ b/tests/config/slurm/slurm.sh
@@ -5,7 +5,7 @@
 #SBATCH --get-user-env=L
 #SBATCH --partition=slurm
 {%- if run_time_max %}
-#SBATCH --time={{run_time_max // 60}}
+#SBATCH --time={{max(1, run_time_max // 60)}}
 {%- endif %}
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}


### PR DESCRIPTION
passing `--time=0` trips SLURM so make sure to request at least one minute of run time.