### PR TITLE
Write output from submission to file on error

### DIFF
--- a/pysqa/utils/basic.py
+++ b/pysqa/utils/basic.py
@@ -422,7 +422,9 @@ class BasisQueueAdapter(object):
                 universal_newlines=True,
                 shell=not isinstance(commands, list),
             )
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
+            with open(os.path.join(working_directory, "pysqa.err"), "w") as f:
+                print(e.stdout, file=f)
             out = None
         if out is not None and split_output:
             return out.split("\n")


### PR DESCRIPTION
This may happen if the queuing system e.g. refused to schedule a run
because of errors in the submission script.

This came up for me because I asked for too much memory by mistake.  It might be worthwhile to add a `memory_max` option to the queue yaml.

I have not checked the other adapters in detail, but it seems at least the `RemoteQueueAdapter` seems to suffer the same problem.