### PR TITLE
Return working directory as part of the queue status

### DIFF
--- a/pysqa/wrapper/sge.py
+++ b/pysqa/wrapper/sge.py
@@ -55,5 +55,6 @@ class SunGridEngineCommands(SchedulerCommands):
                 "user": df_merge.JB_owner,
                 "jobname": df_merge.JB_name,
                 "status": df_merge.state,
+                "working_directory": [""] * len(df_merge),
             }
         )

--- a/pysqa/wrapper/slurm.py
+++ b/pysqa/wrapper/slurm.py
@@ -46,7 +46,13 @@ class SlurmCommands(SchedulerCommands):
                 ]
             )
         else:
-            job_id_lst, user_lst, status_lst, job_name_lst, working_directory_lst = [], [], [], [], []
+            job_id_lst, user_lst, status_lst, job_name_lst, working_directory_lst = (
+                [],
+                [],
+                [],
+                [],
+                [],
+            )
         df = pandas.DataFrame(
             {
                 "jobid": job_id_lst,

--- a/pysqa/wrapper/slurm.py
+++ b/pysqa/wrapper/slurm.py
@@ -29,7 +29,7 @@ class SlurmCommands(SchedulerCommands):
 
     @property
     def get_queue_status_command(self):
-        return ["squeue", "--format", "%A|%u|%t|%.15j", "--noheader"]
+        return ["squeue", "--format", "%A|%u|%t|%.15j|%Z", "--noheader"]
 
     @staticmethod
     def get_job_id_from_output(queue_submit_output):
@@ -39,20 +39,21 @@ class SlurmCommands(SchedulerCommands):
     def convert_queue_status(queue_status_output):
         line_split_lst = [line.split("|") for line in queue_status_output.splitlines()]
         if len(line_split_lst) != 0:
-            job_id_lst, user_lst, status_lst, job_name_lst = zip(
+            job_id_lst, user_lst, status_lst, job_name_lst, working_directory_lst = zip(
                 *[
-                    (int(jobid), user, status.lower(), jobname)
-                    for jobid, user, status, jobname in line_split_lst
+                    (int(jobid), user, status.lower(), jobname, working_directory)
+                    for jobid, user, status, jobname, working_directory in line_split_lst
                 ]
             )
         else:
-            job_id_lst, user_lst, status_lst, job_name_lst = [], [], [], []
+            job_id_lst, user_lst, status_lst, job_name_lst, working_directory_lst = [], [], [], [], []
         df = pandas.DataFrame(
             {
                 "jobid": job_id_lst,
                 "user": user_lst,
                 "jobname": job_name_lst,
                 "status": status_lst,
+                "working_directory": working_directory_lst,
             }
         )
         df.loc[df.status == "r", "status"] = "running"

--- a/tests/test_queueadapter.py
+++ b/tests/test_queueadapter.py
@@ -137,7 +137,7 @@ class TestRunmode(unittest.TestCase):
         self.assertEqual(self.slurm._adapter._commands.delete_job_command, ["scancel"])
         self.assertEqual(
             self.slurm._adapter._commands.get_queue_status_command,
-            ["squeue", "--format", "%A|%u|%t|%.15j", "--noheader"],
+            ["squeue", "--format", "%A|%u|%t|%.15j|%Z", "--noheader"],
         )
         self.assertEqual(self.moab._adapter._commands.submit_job_command, ["msub"])
         self.assertEqual(
@@ -148,7 +148,7 @@ class TestRunmode(unittest.TestCase):
         )
         self.assertEqual(
             self.gent._adapter._commands.get_queue_status_command,
-            ["squeue", "--format", "%A|%u|%t|%.15j", "--noheader"],
+            ["squeue", "--format", "%A|%u|%t|%.15j|%Z", "--noheader"],
         )
 
     def test__list_command_to_be_executed(self):
@@ -254,6 +254,7 @@ class TestRunmode(unittest.TestCase):
                 "user": df_merge.user,
                 "jobname": df_merge.jobname,
                 "status": df_merge.status,
+                "working_directory": [""] * len(df_merge),
             }
         )
         self.assertTrue(


### PR DESCRIPTION
The idea is to use this functionality in pyiron installations without database to identify which job in the queuing system belongs to which calculation on the filesystem. 