### PR TITLE
Check the existence of the remote file before transferring the file

### DIFF
--- a/pysqa/ext/remote.py
+++ b/pysqa/ext/remote.py
@@ -176,6 +176,7 @@ class RemoteQueueAdapter(BasisQueueAdapter):
         for file_src, file_dst in tqdm(file_dict.items()):
             if transfer_back:
                 try:
+                    sftp_client.stat(file_dst)
                     sftp_client.get(file_dst, file_src)
                 except FileNotFoundError:
                     pass

--- a/pysqa/ext/remote.py
+++ b/pysqa/ext/remote.py
@@ -176,7 +176,10 @@ class RemoteQueueAdapter(BasisQueueAdapter):
         for file_src, file_dst in tqdm(file_dict.items()):
             if transfer_back:
                 try:
-                    sftp_client.stat(file_dst)  # Check remote file existence
+                    # Check remote file existence.
+                    # If the remote file does not exist, sftp_client.get() will make the local file empty
+                    # sftp_client.stat() can throw an exception early to prevent the execution of sftp_client.get().
+                    sftp_client.stat(file_dst)
                     sftp_client.get(file_dst, file_src)
                 except FileNotFoundError:
                     pass

--- a/pysqa/ext/remote.py
+++ b/pysqa/ext/remote.py
@@ -176,7 +176,7 @@ class RemoteQueueAdapter(BasisQueueAdapter):
         for file_src, file_dst in tqdm(file_dict.items()):
             if transfer_back:
                 try:
-                    sftp_client.stat(file_dst)
+                    sftp_client.stat(file_dst)  # Check remote file existence
                     sftp_client.get(file_dst, file_src)
                 except FileNotFoundError:
                     pass


### PR DESCRIPTION
If the remote file doesn't exist, the statement `sftp_client.get(file_dst, file_src)` will raise `FileNotFoundError`. The expected behavior is to skip. But the `paramiko` sftp connection will make the local file to empty. Thus, add `sftp_client.stat(file_dst)` to check remote file existence. If the remote file is not exists, the `FileNotFoundError` will raise before the the file transfer.