### PR TITLE
Add manual two factor authentication

### DIFF
--- a/pysqa/ext/remote.py
+++ b/pysqa/ext/remote.py
@@ -36,7 +36,9 @@ class RemoteQueueAdapter(BasisQueueAdapter):
         else:
             self._ssh_key_passphrase = None
         if "ssh_two_factor_authentication" in config.keys():
-            self._ssh_two_factor_authentication = config["ssh_two_factor_authentication"]
+            self._ssh_two_factor_authentication = config[
+                "ssh_two_factor_authentication"
+            ]
         else:
             self._ssh_two_factor_authentication = False
         if "ssh_authenticator_service" in config.keys():

--- a/pysqa/ext/remote.py
+++ b/pysqa/ext/remote.py
@@ -35,8 +35,13 @@ class RemoteQueueAdapter(BasisQueueAdapter):
             self._ssh_key_passphrase = config["ssh_key_passphrase"]
         else:
             self._ssh_key_passphrase = None
+        if "ssh_two_factor_authentication" in config.keys():
+            self._ssh_two_factor_authentication = config["ssh_two_factor_authentication"]
+        else:
+            self._ssh_two_factor_authentication = False
         if "ssh_authenticator_service" in config.keys():
             self._ssh_authenticator_service = config["ssh_authenticator_service"]
+            self._ssh_two_factor_authentication = True
         else:
             self._ssh_authenticator_service = None
         if "ssh_proxy_host" in config.keys():
@@ -228,7 +233,11 @@ class RemoteQueueAdapter(BasisQueueAdapter):
                 username=self._ssh_username,
                 key_filename=self._ssh_key,
             )
-        elif self._ssh_password is not None and self._ssh_authenticator_service is None:
+        elif (
+            self._ssh_password is not None
+            and self._ssh_authenticator_service is None
+            and not self._ssh_two_factor_authentication
+        ):
             ssh.connect(
                 hostname=self._ssh_host,
                 port=self._ssh_port,
@@ -238,6 +247,7 @@ class RemoteQueueAdapter(BasisQueueAdapter):
         elif (
             self._ssh_password is not None
             and self._ssh_authenticator_service is not None
+            and self._ssh_two_factor_authentication
         ):
 
             def authentication(title, instructions, prompt_list):
@@ -259,6 +269,22 @@ class RemoteQueueAdapter(BasisQueueAdapter):
 
             ssh._transport.auth_interactive(
                 username=self._ssh_username, handler=authentication, submethods=""
+            )
+        elif (
+            self._ssh_password is not None
+            and self._ssh_authenticator_service is None
+            and self._ssh_two_factor_authentication
+        ):
+            ssh.connect(
+                hostname=self._ssh_host,
+                port=self._ssh_port,
+                username=self._ssh_username,
+                password=self._ssh_password,
+            )
+
+            print("Manual authenticaion")
+            ssh._transport.auth_interactive_dumb(
+                username=self._ssh_username, handler=None, submethods=""
             )
         else:
             raise ValueError("Un-supported authentication method.")

--- a/pysqa/ext/remote.py
+++ b/pysqa/ext/remote.py
@@ -281,8 +281,6 @@ class RemoteQueueAdapter(BasisQueueAdapter):
                 username=self._ssh_username,
                 password=self._ssh_password,
             )
-
-            print("Manual authenticaion")
             ssh._transport.auth_interactive_dumb(
                 username=self._ssh_username, handler=None, submethods=""
             )


### PR DESCRIPTION
Example configuration:
```
queue_type: REMOTE
queue_primary: cm
ssh_host: gateafs.rzg.mpg.de
ssh_proxy_host: cmti001.bc.rzg.mpg.de
ssh_username: janj
known_hosts: ~/.ssh/known_hosts
ssh_password:  ********
ssh_two_factor_authentication: True
ssh_remote_config_dir: /u/system/SLES12/soft/pyiron/dev/pyiron-resources-cmmc/queues/
ssh_remote_path: /cmmc/u/janj/remote/
ssh_local_path: /Users/jan/notebooks/
ssh_continous_connection: True
queues:
  cm: {cores_max: 1200, cores_min: 1, run_time_max: 5760}
```