### PR TITLE
Define interface in QueueAdapterAbstractClass

### DIFF
--- a/pysqa/base/abstract.py
+++ b/pysqa/base/abstract.py
@@ -1,0 +1,80 @@
+from abc import ABC, abstractmethod
+from typing import Optional, List, Union
+
+from jinja2 import Template
+import pandas
+
+
+class QueueAdapterAbstractClass(ABC):
+    @abstractmethod
+    def submit_job(
+        self,
+        queue: Optional[str] = None,
+        job_name: Optional[str] = None,
+        working_directory: Optional[str] = None,
+        cores: Optional[int] = None,
+        memory_max: Optional[int] = None,
+        run_time_max: Optional[int] = None,
+        dependency_list: Optional[List[str]] = None,
+        command: Optional[str] = None,
+        submission_template: Optional[Union[str, Template]] = None,
+        **kwargs,
+    ) -> Union[int, None]:
+        pass
+
+    @abstractmethod
+    def enable_reservation(self, process_id: int):
+        pass
+
+    @abstractmethod
+    def delete_job(self, process_id: int) -> Union[str, None]:
+        pass
+
+    @abstractmethod
+    def get_queue_status(self, user: Optional[str] = None) -> pandas.DataFrame:
+        """
+        Get the status of the queue.
+
+        Args:
+            user (str): The user to filter the queue status for.
+
+        Returns:
+            pandas.DataFrame: The queue status.
+        """
+        pass
+
+    @abstractmethod
+    def get_status_of_my_jobs(self) -> pandas.DataFrame:
+        """
+        Get the status of the user's jobs.
+
+        Returns:
+            pandas.DataFrame: The status of the user's jobs.
+        """
+        pass
+
+    @abstractmethod
+    def get_status_of_job(self, process_id: int) -> Union[str, None]:
+        """
+        Get the status of a job.
+
+        Args:
+            process_id (int): The process ID.
+
+        Returns:
+            str: The status of the job.results_lst.append(df_selected.values[0])
+        """
+        pass
+
+    @abstractmethod
+    def get_status_of_jobs(self, process_id_lst: List[int]) -> List[str]:
+        """
+        Get the status of multiple jobs.
+
+        Args:
+            process_id_lst (list[int]): List of process IDs.
+
+        Returns:
+            list[str]: List of job statuses.
+        """
+        pass

--- a/pysqa/base/abstract.py
+++ b/pysqa/base/abstract.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
-from jinja2 import Template
 import pandas
+from jinja2 import Template
 
 
 class QueueAdapterAbstractClass(ABC):

--- a/pysqa/base/core.py
+++ b/pysqa/base/core.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple, Union
 import pandas
 from jinja2 import Template
 
+from pysqa.base.abstract import QueueAdapterAbstractClass
 from pysqa.wrapper.abstract import SchedulerCommands
 
 queue_type_dict = {
@@ -111,7 +112,7 @@ def get_queue_commands(queue_type: str) -> Union[SchedulerCommands, None]:
         )
 
 
-class QueueAdapterCore(object):
+class QueueAdapterCore(QueueAdapterAbstractClass):
     """
     The goal of the QueueAdapter class is to make submitting to a queue system as easy as starting another sub process
     locally.

--- a/pysqa/queueadapter.py
+++ b/pysqa/queueadapter.py
@@ -1,8 +1,8 @@
 import os
 from typing import List, Optional, Tuple, Union
 
-from jinja2 import Template
 import pandas
+from jinja2 import Template
 
 from pysqa.base.abstract import QueueAdapterAbstractClass
 from pysqa.base.config import QueueAdapterWithConfig, read_config

--- a/pysqa/queueadapter.py
+++ b/pysqa/queueadapter.py
@@ -1,14 +1,16 @@
 import os
 from typing import List, Optional, Tuple, Union
 
+from jinja2 import Template
 import pandas
 
+from pysqa.base.abstract import QueueAdapterAbstractClass
 from pysqa.base.config import QueueAdapterWithConfig, read_config
 from pysqa.base.core import execute_command
 from pysqa.ext.modular import ModularQueueAdapter
 
 
-class QueueAdapter(object):
+class QueueAdapter(QueueAdapterAbstractClass):
     """
     The goal of the QueueAdapter class is to make submitting to a queue system as easy as starting another sub process
     locally.
@@ -164,6 +166,7 @@ class QueueAdapter(object):
         run_time_max: Optional[int] = None,
         dependency_list: Optional[List[str]] = None,
         command: Optional[str] = None,
+        submission_template: Optional[Union[str, Template]] = None,
         **kwargs,
     ) -> int:
         """
@@ -194,6 +197,7 @@ class QueueAdapter(object):
             run_time_max=run_time_max,
             dependency_list=dependency_list,
             command=command,
+            submission_template=submission_template,
             **kwargs,
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an abstract base class for queue management, enhancing the structure and functionality of job submissions.
	- Added support for submission templates in job submissions, providing greater flexibility.

- **Improvements**
	- Updated existing queue adapter classes to inherit from the new abstract base class, ensuring a consistent interface for job management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->