### PR TITLE
Add submission_script_path to write run_queue.sh script to a different location

### DIFF
--- a/pysqa/base/modular.py
+++ b/pysqa/base/modular.py
@@ -73,7 +73,7 @@ class ModularQueueAdapter(QueueAdapterWithConfig):
             int: The cluster queue ID.
 
         """
-        working_directory, queue_script_path = self._write_queue_script(
+        working_directory, submission_script_path = self._write_queue_script(
             queue=queue,
             job_name=job_name,
             working_directory=working_directory,
@@ -87,7 +87,7 @@ class ModularQueueAdapter(QueueAdapterWithConfig):
         cluster_module = self._queue_to_cluster_dict[queue]
         commands = self._switch_cluster_command(
             cluster_module=cluster_module
-        ) + self._list_command_to_be_executed(queue_script_path=queue_script_path)
+        ) + self._list_command_to_be_executed(submission_script_path=submission_script_path)
         out = self._execute_command(
             commands=commands,
             working_directory=working_directory,

--- a/pysqa/base/modular.py
+++ b/pysqa/base/modular.py
@@ -87,7 +87,9 @@ class ModularQueueAdapter(QueueAdapterWithConfig):
         cluster_module = self._queue_to_cluster_dict[queue]
         commands = self._switch_cluster_command(
             cluster_module=cluster_module
-        ) + self._list_command_to_be_executed(submission_script_path=submission_script_path)
+        ) + self._list_command_to_be_executed(
+            submission_script_path=submission_script_path
+        )
         out = self._execute_command(
             commands=commands,
             working_directory=working_directory,

--- a/pysqa/queueadapter.py
+++ b/pysqa/queueadapter.py
@@ -197,6 +197,7 @@ class QueueAdapter(QueueAdapterAbstractClass):
         dependency_list: Optional[List[str]] = None,
         command: Optional[str] = None,
         submission_template: Optional[Union[str, Template]] = None,
+        submission_script_path: Optional[str] = None,
         **kwargs,
     ) -> int:
         """
@@ -212,6 +213,8 @@ class QueueAdapter(QueueAdapterAbstractClass):
             run_time_max (int/None):  Maximum runtime in seconds (optional)
             dependency_list(list[str]/None: Job ids of jobs to be completed before starting (optional)
             command (str/None): shell command to run in the job
+            submission_template (str/Template): Jinja2 template to write submission script.
+            submission_script_path (str/None): path to write the submission script to.
             **kwargs: allows writing additional parameters to the job submission script if they are available in the
                       corresponding template.
 
@@ -228,6 +231,7 @@ class QueueAdapter(QueueAdapterAbstractClass):
             dependency_list=dependency_list,
             command=command,
             submission_template=submission_template,
+            submission_script_path=submission_script_path,
             **kwargs,
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `submission_script_path` parameter in the job submission process, allowing users to specify the script's location.
	- Updated documentation to reflect the new parameter and its purpose.

- **Bug Fixes**
	- Enhanced error handling for whitespace in the working directory during job submissions.

- **Refactor**
	- Improved clarity in variable naming related to script paths across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->