### PR TITLE
Bump setuptools from 80.1.0 to 80.3.1 (#402)

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -13,4 +13,4 @@ dependencies:
 - tqdm =4.67.1
 - jupyter-book =1.0.0
 - python =3.12
-- setuptools =80.1.0
+- setuptools =80.3.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,4 +8,4 @@ dependencies:
 - jinja2 =3.1.6
 - paramiko =3.5.1
 - tqdm =4.67.1
-- setuptools =80.1.0
+- setuptools =80.3.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,4 +12,4 @@ dependencies:
 - cloudpickle =3.0.0
 - flux-core =0.59.0
 - versioneer =0.28
-- setuptools =80.1.0
+- setuptools =80.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "jinja2==3.1.6", 
     "pandas==2.2.3", 
     "pyyaml==6.0.2", 
-    "setuptools==80.1.0",
+    "setuptools==80.3.1",
     "versioneer[toml]==0.29",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
* Bump setuptools from 80.1.0 to 80.3.1

Bumps [setuptools](https://github.com/pypa/setuptools) from 80.1.0 to 80.3.1.
- [Release notes](https://github.com/pypa/setuptools/releases)
- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
- [Commits](https://github.com/pypa/setuptools/compare/v80.1.0...v80.3.1)

---
updated-dependencies:
- dependency-name: setuptools dependency-version: 80.3.1 dependency-type: direct:production update-type: version-update:semver-minor ...



* [dependabot skip] Update environment

---------