### PR TITLE
Remote: Add option to specify Python executable

### DIFF
--- a/pysqa/base/remote.py
+++ b/pysqa/base/remote.py
@@ -240,7 +240,8 @@ class RemoteQueueAdapter(QueueAdapterWithConfig):
         )
         remote_dict = json.loads(
             self._execute_remote_command(
-                command=self._python_executable + " -m pysqa --list --working_directory "
+                command=self._python_executable
+                + " -m pysqa --list --working_directory "
                 + remote_working_directory
             )
         )
@@ -461,7 +462,12 @@ class RemoteQueueAdapter(QueueAdapterWithConfig):
         Returns:
             str: The remote command.
         """
-        return self._python_executable + " -m pysqa --config_directory " + self._ssh_remote_config_dir + " "
+        return (
+            self._python_executable
+            + " -m pysqa --config_directory "
+            + self._ssh_remote_config_dir
+            + " "
+        )
 
     def _get_queue_status_command(self) -> str:
         """

--- a/pysqa/base/remote.py
+++ b/pysqa/base/remote.py
@@ -127,6 +127,7 @@ class RemoteQueueAdapter(QueueAdapterWithConfig):
         self._ssh_continous_connection = config.get("ssh_continous_connection", False)
         self._ssh_connection = None
         self._ssh_proxy_connection = None
+        self._python_executable = config.get("python_executable", "python")
         self._remote_flag = True
 
     def convert_path_to_remote(self, path: str) -> str:
@@ -239,7 +240,7 @@ class RemoteQueueAdapter(QueueAdapterWithConfig):
         )
         remote_dict = json.loads(
             self._execute_remote_command(
-                command="python -m pysqa --list --working_directory "
+                command=self._python_executable + " -m pysqa --list --working_directory "
                 + remote_working_directory
             )
         )
@@ -460,7 +461,7 @@ class RemoteQueueAdapter(QueueAdapterWithConfig):
         Returns:
             str: The remote command.
         """
-        return "python -m pysqa --config_directory " + self._ssh_remote_config_dir + " "
+        return self._python_executable + " -m pysqa --config_directory " + self._ssh_remote_config_dir + " "
 
     def _get_queue_status_command(self) -> str:
         """

--- a/tests/config/remote_alternative/queue.yaml
+++ b/tests/config/remote_alternative/queue.yaml
@@ -9,5 +9,6 @@ ssh_remote_path: /u/hpcuser/remote/
 ssh_local_path: /home/localuser/projects/
 ssh_continous_connection: False
 ssh_port: 22
+python_executable: python3
 queues:
   remote: {cores_max: 100, cores_min: 10, run_time_max: 259200}

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -33,6 +33,7 @@ class TestRemoteQueueAdapter(unittest.TestCase):
 
     def test_remote_flag(self):
         self.assertTrue(self.remote._adapter.remote_flag)
+        self.assertTrue(self.remote_alternative._adapter.remote_flag)
 
     def test_ssh_delete_file_on_remote(self):
         self.assertEqual(self.remote.ssh_delete_file_on_remote, False)
@@ -48,19 +49,34 @@ class TestRemoteQueueAdapter(unittest.TestCase):
             self.remote.submit_job(queue="remote", dependency_list=[])
 
     def test_submit_command(self):
-        command = self.remote._adapter._submit_command(
-            queue="remote",
-            job_name="test",
-            working_directory="/home/localuser/projects/test",
-            cores=str(1),
-            memory_max=str(1),
-            run_time_max=str(1),
-            command_str="/bin/true",
-        )
-        self.assertEqual(
-            command,
-            'python -m pysqa --config_directory /u/share/pysqa/resources/queues/ --submit --queue remote --job_name test --working_directory /home/localuser/projects/test --cores 1 --memory 1 --run_time 1 --command "/bin/true" ',
-        )
+        with self.subTest("remote config"):
+            command = self.remote._adapter._submit_command(
+                queue="remote",
+                job_name="test",
+                working_directory="/home/localuser/projects/test",
+                cores=str(1),
+                memory_max=str(1),
+                run_time_max=str(1),
+                command_str="/bin/true",
+            )
+            self.assertEqual(
+                command,
+                'python -m pysqa --config_directory /u/share/pysqa/resources/queues/ --submit --queue remote --job_name test --working_directory /home/localuser/projects/test --cores 1 --memory 1 --run_time 1 --command "/bin/true" ',
+            )
+        with self.subTest("alternative remote config"):
+            command = self.remote_alternative._adapter._submit_command(
+                queue="remote",
+                job_name="test",
+                working_directory="/home/localuser/projects/test",
+                cores=str(1),
+                memory_max=str(1),
+                run_time_max=str(1),
+                command_str="/bin/true",
+            )
+            self.assertEqual(
+                command,
+                'python3 -m pysqa --config_directory /u/share/pysqa/resources/queues/ --submit --queue remote --job_name test --working_directory /home/localuser/projects/test --cores 1 --memory 1 --run_time 1 --command "/bin/true" ',
+            )
 
     def test_get_queue_status_command(self):
         command = self.remote._adapter._get_queue_status_command()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the Python executable used for remote commands, allowing greater flexibility for remote job execution environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->