### PR TITLE
feat: Increase test coverage for pysqa/base/remote.py

### DIFF
--- a/pysqa/_version.py
+++ b/pysqa/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "0.1.dev1+g0a7b083"
-__version_tuple__ = version_tuple = (0, 1, "dev1", "g0a7b083")
+__version__ = version = "0.0.1"
+__version_tuple__ = version_tuple = (0, 0, 1)

--- a/pysqa/_version.py
+++ b/pysqa/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "0.0.1"
-__version_tuple__ = version_tuple = (0, 0, 1)
+__version__ = version = '0.1.dev1+g0a7b083'
+__version_tuple__ = version_tuple = (0, 1, 'dev1', 'g0a7b083')

--- a/pysqa/_version.py
+++ b/pysqa/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev1+g0a7b083'
-__version_tuple__ = version_tuple = (0, 1, 'dev1', 'g0a7b083')
+__version__ = version = "0.1.dev1+g0a7b083"
+__version_tuple__ = version_tuple = (0, 1, "dev1", "g0a7b083")

--- a/tests/config/remote_rebex/queue.yaml
+++ b/tests/config/remote_rebex/queue.yaml
@@ -9,6 +9,6 @@ ssh_remote_path: /
 ssh_local_path: /home/localuser/projects/
 ssh_continous_connection: False
 ssh_port: 22
-python_executable: python3
+python_executable: python
 queues:
   remote: {cores_max: 100, cores_min: 10, run_time_max: 259200}

--- a/tests/config/remote_rebex/queue.yaml
+++ b/tests/config/remote_rebex/queue.yaml
@@ -9,6 +9,6 @@ ssh_remote_path: /
 ssh_local_path: /home/localuser/projects/
 ssh_continous_connection: False
 ssh_port: 22
-python_executable: python
+python_executable: python3
 queues:
   remote: {cores_max: 100, cores_min: 10, run_time_max: 259200}

--- a/tests/test_remote_auth.py
+++ b/tests/test_remote_auth.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+from pysqa import QueueAdapter
+
+try:
+    import paramiko
+    from tqdm import tqdm
+    from pysqa.base.remote import get_transport
+
+    skip_remote_test = False
+except ImportError:
+    skip_remote_test = True
+
+
+@unittest.skipIf(
+    skip_remote_test,
+    "Either paramiko or tqdm are not installed, so the remote queue adapter tests are skipped.",
+)
+class TestRemoteQueueAdapterAuth(unittest.TestCase):
+    def test_password_auth(self):
+        path = os.path.dirname(os.path.abspath(__file__))
+        remote = QueueAdapter(directory=os.path.join(path, "config/remote_rebex"))
+        remote._adapter._ssh_ask_for_password = False
+        remote._adapter._ssh_key = None
+        self.assertIsNotNone(remote._adapter._open_ssh_connection())
+
+    def test_key_auth(self):
+        path = os.path.dirname(os.path.abspath(__file__))
+        remote = QueueAdapter(directory=os.path.join(path, "config/remote_rebex"))
+        remote._adapter._ssh_password = None
+        with self.assertRaises(paramiko.ssh_exception.AuthenticationException):
+            remote._adapter._open_ssh_connection()
+
+    def test_two_factor_auth(self):
+        path = os.path.dirname(os.path.abspath(__file__))
+        remote = QueueAdapter(directory=os.path.join(path, "config/remote_rebex"))
+        remote._adapter._ssh_two_factor_authentication = True
+        with self.assertRaises(paramiko.ssh_exception.AuthenticationException):
+            remote._adapter._open_ssh_connection()

--- a/tests/test_remote_auth.py
+++ b/tests/test_remote_auth.py
@@ -28,7 +28,7 @@ class TestRemoteQueueAdapterAuth(unittest.TestCase):
         path = os.path.dirname(os.path.abspath(__file__))
         remote = QueueAdapter(directory=os.path.join(path, "config/remote_rebex"))
         remote._adapter._ssh_password = None
-        with self.assertRaises(paramiko.ssh_exception.AuthenticationException):
+        with self.assertRaises(ValueError):
             remote._adapter._open_ssh_connection()
 
     def test_two_factor_auth(self):


### PR DESCRIPTION
- Add tests for get_job_from_remote
- Add tests for authentication methods in _open_ssh_connection
- Increase coverage of pysqa/base/remote.py from 72% to 80%