### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,9 @@ repos:
         files: ^pysqa/
       - id: ruff-format
         name: ruff format
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.1
+    hooks:
+    - id: codespell

--- a/notebooks/example_config.ipynb
+++ b/notebooks/example_config.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Python Interface Config\n",
-    "The `pysqa` package primarily defines one class, that is the `QueueAdapter`. It loads the configuration from a configuration directory, initializes the corrsponding adapter for the specific queuing system and provides a high level interface for users to interact with the queuing system. The `QueueAdapter` can be imported using:"
+    "The `pysqa` package primarily defines one class, that is the `QueueAdapter`. It loads the configuration from a configuration directory, initializes the corresponding adapter for the specific queuing system and provides a high level interface for users to interact with the queuing system. The `QueueAdapter` can be imported using:"
    ]
   },
   {
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "id": "7e3cf646-d4e7-4b1e-ab47-f07342d7a5a2",
    "metadata": {},
-   "source": "After the initial import the class is initialized using the configuration directory specificed by the `directory` parameter which defaults to `\"~/.queues\"`. In this example we load the configuration from the `test` directory: "
+   "source": "After the initial import the class is initialized using the configuration directory specified by the `directory` parameter which defaults to `\"~/.queues\"`. In this example we load the configuration from the `test` directory: "
   },
   {
    "cell_type": "code",

--- a/notebooks/example_queue_type.ipynb
+++ b/notebooks/example_queue_type.ipynb
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "source": [
     "# Dynamic Python Interface\n",
-    "The `pysqa` package primarily defines one class, that is the `QueueAdapter`. It can either load the configuration from a configuration directory, or initializes the corrsponding adapter for the specific queuing system type `queue_type` and provides a high level interface for users to interact with the queuing system. The `QueueAdapter` can be imported using:"
+    "The `pysqa` package primarily defines one class, that is the `QueueAdapter`. It can either load the configuration from a configuration directory, or initializes the corresponding adapter for the specific queuing system type `queue_type` and provides a high level interface for users to interact with the queuing system. The `QueueAdapter` can be imported using:"
    ],
    "metadata": {}
   },
@@ -44,7 +44,7 @@
   {
    "id": "7e3cf646-d4e7-4b1e-ab47-f07342d7a5a2",
    "cell_type": "markdown",
-   "source": "After the initial import the class is initialized using the queuing system type specificed by the `queue_type` parameter. In this example we load the `flux` as queuing system interface: ",
+   "source": "After the initial import the class is initialized using the queuing system type specified by the `queue_type` parameter. In this example we load the `flux` as queuing system interface: ",
    "metadata": {}
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,9 @@ path = "pysqa/_version.py"
 [tool.coverage.run]
 omit = ["pysqa/_version.py", "tests/*"]
 command_line = "-m unittest discover tests"
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+ignore-regex = '^\s*"image/\S+": ".*'
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

But congrats - no typos elsewhere!?!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added automated spelling checks via a Codespell workflow for pushes and pull requests.
  - Integrated Codespell into pre-commit to catch typos before commits.
  - Introduced centralized Codespell configuration for consistent checks across the project.

- Documentation
  - Corrected minor typos in example notebooks to improve clarity (e.g., “corrsponding” → “corresponding”, “specificed” → “specified”).
  - No functional changes; content updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->