### PR TITLE
Update hatchling to 1.30.1

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -14,5 +14,5 @@ dependencies:
 - jupyter-book =1.0.0
 - python =3.12
 - pydantic =2.13.4
-- hatchling =1.29.0
+- hatchling =1.30.1
 - hatch-vcs =0.5.0

--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -4,5 +4,5 @@ dependencies:
 - pandas =3.0.2
 - pyyaml =6.0.3
 - jinja2 =3.1.6
-- hatchling =1.29.0
+- hatchling =1.30.1
 - hatch-vcs =0.5.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,6 +8,6 @@ dependencies:
 - jinja2 =3.1.6
 - paramiko =5.0.0
 - tqdm =4.67.3
-- hatchling =1.29.0
+- hatchling =1.30.1
 - hatch-vcs =0.5.0
 - pydantic =2.13.4

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,6 +9,6 @@ dependencies:
 - jinja2 =3.1.6
 - paramiko =5.0.0
 - tqdm =4.67.3
-- hatchling =1.29.0
+- hatchling =1.30.1
 - hatch-vcs =0.5.0
 - pydantic =2.13.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "jinja2==3.1.6", 
     "pandas==3.0.2", 
     "pyyaml==6.0.3", 
-    "hatchling==1.29.0",
+    "hatchling==1.30.1",
     "hatch-vcs==0.5.0",
 ]
 build-backend = "hatchling.build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hatchling Python build tool dependency from 1.29.0 to 1.30.1 across CI configurations and build system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->