### PR TITLE
slurm: switch from --cpus-per-task to --ntasks

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -165,7 +165,7 @@ The queue named `slurm` is defined based on a submission script template named `
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}G
 {%- endif %}
-#SBATCH --cpus-per-task={{cores}}
+#SBATCH --ntasks={{cores}}
 
 {{command}}
 ```

--- a/src/pysqa/wrapper/slurm.py
+++ b/src/pysqa/wrapper/slurm.py
@@ -22,7 +22,7 @@ template = """\
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}G
 {%- endif %}
-#SBATCH --cpus-per-task={{cores}}
+#SBATCH --ntasks={{cores}}
 
 {{command}}
 """

--- a/tests/static/gent/slurm.sh
+++ b/tests/static/gent/slurm.sh
@@ -10,6 +10,6 @@
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}
 {%- endif %}
-#SBATCH --cpus-per-task={{cores}}
+#SBATCH --ntasks={{cores}}
 
 {{command}}

--- a/tests/static/slurm/slurm.sh
+++ b/tests/static/slurm/slurm.sh
@@ -13,6 +13,6 @@
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}G
 {%- endif %}
-#SBATCH --cpus-per-task={{cores}}
+#SBATCH --ntasks={{cores}}
 
 {{command}}

--- a/tests/static/slurm/slurm_extra.sh
+++ b/tests/static/slurm/slurm_extra.sh
@@ -19,6 +19,6 @@
 {%- if memory_max %}
 #SBATCH --mem={{memory_max}}G
 {%- endif %}
-#SBATCH --cpus-per-task={{cores}}
+#SBATCH --ntasks={{cores}}
 
 {{command}}

--- a/tests/unit/base/test_cmd.py
+++ b/tests/unit/base/test_cmd.py
@@ -80,7 +80,7 @@ class TestCMD(unittest.TestCase):
             "#SBATCH --time=1\n",
             '#SBATCH --dependency=afterok:1\n',
             "#SBATCH --mem=1GBG\n",
-            "#SBATCH --cpus-per-task=10\n",
+            "#SBATCH --ntasks=10\n",
             "\n",
             "echo hello",
         ]

--- a/tests/unit/wrapper/test_slurm.py
+++ b/tests/unit/wrapper/test_slurm.py
@@ -125,7 +125,7 @@ class TestSlurmQueueAdapter(unittest.TestCase):
 #SBATCH --get-user-env=L
 #SBATCH --partition=slurm
 #SBATCH --time=4320
-#SBATCH --cpus-per-task=10
+#SBATCH --ntasks=10
 
 echo \"hello\""""
         self.assertEqual(content, output)
@@ -153,7 +153,7 @@ echo \"hello\""""
 #SBATCH --partition=slurm
 #SBATCH --account=123456
 #SBATCH --time=4320
-#SBATCH --cpus-per-task=10
+#SBATCH --ntasks=10
 
 echo \"hello\""""
         self.assertEqual(content, output)
@@ -309,7 +309,7 @@ class TestSlurmQueueAdapterDefault(unittest.TestCase):
 #SBATCH --get-user-env=L
 #SBATCH --partition=slurm
 #SBATCH --time=4320
-#SBATCH --cpus-per-task=10
+#SBATCH --ntasks=10
 
 echo \"hello\""""
         self.assertEqual(content, output)
@@ -335,7 +335,7 @@ echo \"hello\""""
 #SBATCH --get-user-env=L
 #SBATCH --partition=slurm
 #SBATCH --time=4320
-#SBATCH --cpus-per-task=10
+#SBATCH --ntasks=10
 
 echo \"hello\""""
         self.assertEqual(content, output)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SLURM job submission scripts to use task-based core allocation instead of per-task CPU allocation.

* **Tests**
  * Updated test expectations to match SLURM submission script changes.

* **Documentation**
  * Updated SLURM submission template reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->