### PR TITLE
Extend unit test coverage to 96% and fix three latent bugs

### DIFF
--- a/src/pysqa/base/core.py
+++ b/src/pysqa/base/core.py
@@ -135,6 +135,8 @@ class QueueAdapterCore(QueueAdapterAbstractClass):
         module_name = queue_type_dict[queue_type]["module_name"]
         if module_name is not None:
             self._submission_template = importlib.import_module(module_name).template
+        else:
+            self._submission_template = None
         self._execute_command_function = execute_command
 
     def submit_job(

--- a/src/pysqa/base/modular.py
+++ b/src/pysqa/base/modular.py
@@ -42,7 +42,7 @@ class ModularQueueAdapter(QueueAdapterWithConfig):
                     "The cluster "
                     + v
                     + " was not found in the list of clusters "
-                    + str(list(self._config["cluster"].keys()))
+                    + str(list(self._config["cluster"]))
                 )
 
     def submit_job(

--- a/tests/unit/base/test_cmd.py
+++ b/tests/unit/base/test_cmd.py
@@ -11,7 +11,9 @@ class TestCMD(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.test_dir = os.path.abspath(os.path.dirname(__file__))
-        cls.config_dir = os.path.abspath(os.path.join(cls.test_dir, "..", "..", "static"))
+        cls.config_dir = os.path.abspath(
+            os.path.join(cls.test_dir, "..", "..", "static")
+        )
 
     def test_console_script_entry_point(self):
         """The ``pysqa`` console script must point at an importable callable.
@@ -104,7 +106,7 @@ class TestCMD(unittest.TestCase):
             "#SBATCH --get-user-env=L\n",
             "#SBATCH --partition=slurm\n",
             "#SBATCH --time=1\n",
-            '#SBATCH --dependency=afterok:1\n',
+            "#SBATCH --dependency=afterok:1\n",
             "#SBATCH --mem=1GBG\n",
             "#SBATCH --ntasks=10\n",
             "\n",
@@ -143,9 +145,7 @@ class TestCMD(unittest.TestCase):
             shell=False,
             error_filename="pysqa.err",
         ):
-            with open(
-                os.path.join(self.config_dir, "slurm", "squeue_output")
-            ) as f:
+            with open(os.path.join(self.config_dir, "slurm", "squeue_output")) as f:
                 return f.read()
 
         self.assert_stdout_command_line(
@@ -179,6 +179,58 @@ class TestCMD(unittest.TestCase):
             + "\n",
         )
 
+    def test_delete_without_id_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            command_line(
+                arguments_lst=[
+                    "--config_directory",
+                    os.path.join(self.config_dir, "slurm"),
+                    "--delete",
+                ],
+                execute_command=None,
+            )
+
+    def test_reservation_without_id_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            command_line(
+                arguments_lst=[
+                    "--config_directory",
+                    os.path.join(self.config_dir, "slurm"),
+                    "--reservation",
+                ],
+                execute_command=None,
+            )
+
+    def test_reservation_with_id(self):
+        def execute_command(
+            commands,
+            working_directory=None,
+            split_output=True,
+            shell=False,
+            error_filename="pysqa.err",
+        ):
+            return "Reservation enabled\n"
+
+        self.assert_stdout_command_line(
+            [
+                "--config_directory",
+                os.path.join(self.config_dir, "sge"),
+                "--reservation",
+                "--id",
+                "1",
+            ],
+            execute_command,
+            "R\n",
+        )
+
+    @unittest.mock.patch("sys.argv", ["pysqa", "--help"])
+    def test_default_arguments_lst_uses_sys_argv(self):
+        with unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            command_line(arguments_lst=None, execute_command=None)
+        self.assertEqual(
+            mock_stdout.getvalue(), "python -m pysqa --help ... coming soon.\n"
+        )
+
     def test_list(self):
         def execute_command(
             commands,
@@ -203,16 +255,10 @@ class TestCMD(unittest.TestCase):
                     "dirs": [os.path.join(self.config_dir, "slurm")],
                     "files": sorted(
                         [
-                            os.path.join(
-                                self.config_dir, "slurm", "squeue_output"
-                            ),
-                            os.path.join(
-                                self.config_dir, "slurm", "slurm_extra.sh"
-                            ),
+                            os.path.join(self.config_dir, "slurm", "squeue_output"),
+                            os.path.join(self.config_dir, "slurm", "slurm_extra.sh"),
                             os.path.join(self.config_dir, "slurm", "slurm.sh"),
-                            os.path.join(
-                                self.config_dir, "slurm", "queue.yaml"
-                            ),
+                            os.path.join(self.config_dir, "slurm", "queue.yaml"),
                         ]
                     ),
                 }

--- a/tests/unit/base/test_cmd.py
+++ b/tests/unit/base/test_cmd.py
@@ -4,7 +4,15 @@ import json
 import unittest
 import unittest.mock
 from importlib.metadata import entry_points
+
 from pysqa.base.cmd import command_line
+
+try:
+    import defusedxml.ElementTree as ETree
+
+    skip_sge_test = False
+except ImportError:
+    skip_sge_test = True
 
 
 class TestCMD(unittest.TestCase):
@@ -201,6 +209,10 @@ class TestCMD(unittest.TestCase):
                 execute_command=None,
             )
 
+    @unittest.skipIf(
+        skip_sge_test,
+        "defusedxml is not installed, so the sun grid engine (SGE) tests are skipped.",
+    )
     def test_reservation_with_id(self):
         def execute_command(
             commands,

--- a/tests/unit/base/test_core.py
+++ b/tests/unit/base/test_core.py
@@ -79,3 +79,24 @@ class TestQueueAdapterCore(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             qa._job_submission_template(queue="some_queue")
         self.assertIn("some_queue", str(context.exception))
+
+    def test_write_queue_script_command_as_list(self):
+        qa = QueueAdapterCore(queue_type="SLURM")
+        working_directory, queue_script_path = qa._write_queue_script(
+            command=["echo ", "hello"]
+        )
+        with open(queue_script_path) as f:
+            content = f.read()
+        self.assertTrue(content.endswith("echo hello"))
+        os.remove(queue_script_path)
+
+    def test_no_commands_for_remote_queue_type(self):
+        # The "REMOTE" queue type has no associated scheduler commands class,
+        # so QueueAdapterCore falls back to its no-op/None branches.
+        qa = QueueAdapterCore(queue_type="REMOTE")
+        self.assertIsNone(qa._commands)
+        self.assertIsNone(qa.enable_reservation(process_id=1))
+        self.assertIsNone(qa.delete_job(process_id=1))
+        self.assertIsNone(qa.get_queue_status())
+        self.assertEqual(qa._list_command_to_be_executed(queue_script_path="x"), [])
+        self.assertEqual(qa._job_submission_template(command="echo hello"), "")

--- a/tests/unit/base/test_modular.py
+++ b/tests/unit/base/test_modular.py
@@ -2,6 +2,13 @@ import unittest
 
 from pysqa.base.modular import ModularQueueAdapter
 
+try:
+    import defusedxml.ElementTree as ETree
+
+    skip_sge_test = False
+except ImportError:
+    skip_sge_test = True
+
 
 def _stub_execute_command(value):
     def execute_command(
@@ -17,6 +24,10 @@ def _stub_execute_command(value):
 
 
 class TestModularQueueAdapter(unittest.TestCase):
+    @unittest.skipIf(
+        skip_sge_test,
+        "defusedxml is not installed, so the sun grid engine (SGE) tests are skipped.",
+    )
     def test_unknown_cluster_raises_value_error(self):
         config = {
             "queue_type": "SGE",
@@ -35,6 +46,10 @@ class TestModularQueueAdapter(unittest.TestCase):
             ModularQueueAdapter(config=config, directory=".")
         self.assertIn("clusterB", str(context.exception))
 
+    @unittest.skipIf(
+        skip_sge_test,
+        "defusedxml is not installed, so the sun grid engine (SGE) tests are skipped.",
+    )
     def test_enable_reservation(self):
         config = {
             "queue_type": "SGE",
@@ -56,6 +71,10 @@ class TestModularQueueAdapter(unittest.TestCase):
         )
         self.assertEqual(qa.enable_reservation(process_id=10), "Reservation enabled")
 
+    @unittest.skipIf(
+        skip_sge_test,
+        "defusedxml is not installed, so the sun grid engine (SGE) tests are skipped.",
+    )
     def test_enable_reservation_no_output(self):
         config = {
             "queue_type": "SGE",

--- a/tests/unit/base/test_modular.py
+++ b/tests/unit/base/test_modular.py
@@ -1,0 +1,95 @@
+import unittest
+
+from pysqa.base.modular import ModularQueueAdapter
+
+
+def _stub_execute_command(value):
+    def execute_command(
+        commands,
+        working_directory=None,
+        split_output=True,
+        shell=False,
+        error_filename="pysqa.err",
+    ):
+        return value
+
+    return execute_command
+
+
+class TestModularQueueAdapter(unittest.TestCase):
+    def test_unknown_cluster_raises_value_error(self):
+        config = {
+            "queue_type": "SGE",
+            "queue_primary": "sge",
+            "cluster": ["clusterA"],
+            "queues": {
+                "sge": {
+                    "cluster": "clusterB",
+                    "cores_max": 100,
+                    "cores_min": 1,
+                    "run_time_max": 1000,
+                }
+            },
+        }
+        with self.assertRaises(ValueError) as context:
+            ModularQueueAdapter(config=config, directory=".")
+        self.assertIn("clusterB", str(context.exception))
+
+    def test_enable_reservation(self):
+        config = {
+            "queue_type": "SGE",
+            "queue_primary": "sge",
+            "cluster": ["clusterA"],
+            "queues": {
+                "sge": {
+                    "cluster": "clusterA",
+                    "cores_max": 100,
+                    "cores_min": 1,
+                    "run_time_max": 1000,
+                }
+            },
+        }
+        qa = ModularQueueAdapter(
+            config=config,
+            directory=".",
+            execute_command=_stub_execute_command(["Reservation enabled", ""]),
+        )
+        self.assertEqual(qa.enable_reservation(process_id=10), "Reservation enabled")
+
+    def test_enable_reservation_no_output(self):
+        config = {
+            "queue_type": "SGE",
+            "queue_primary": "sge",
+            "cluster": ["clusterA"],
+            "queues": {
+                "sge": {
+                    "cluster": "clusterA",
+                    "cores_max": 100,
+                    "cores_min": 1,
+                    "run_time_max": 1000,
+                }
+            },
+        }
+        qa = ModularQueueAdapter(
+            config=config, directory=".", execute_command=_stub_execute_command(None)
+        )
+        self.assertIsNone(qa.enable_reservation(process_id=10))
+
+    def test_get_queue_status_no_commands(self):
+        # The "REMOTE" queue type has no associated scheduler commands class,
+        # so get_queue_status() short-circuits to None.
+        config = {
+            "queue_type": "REMOTE",
+            "queue_primary": "remote",
+            "cluster": ["clusterA"],
+            "queues": {
+                "remote": {
+                    "cluster": "clusterA",
+                    "cores_max": 100,
+                    "cores_min": 1,
+                    "run_time_max": 1000,
+                }
+            },
+        }
+        qa = ModularQueueAdapter(config=config, directory=".")
+        self.assertIsNone(qa.get_queue_status())

--- a/tests/unit/base/test_remote_ssh_connection.py
+++ b/tests/unit/base/test_remote_ssh_connection.py
@@ -346,6 +346,10 @@ class TestRemoteQueueAdapterPublicMethods(unittest.TestCase):
             df_filtered = remote._adapter.get_queue_status(user="janj")
         self.assertEqual(list(df_filtered["jobid"]), [1])
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "Skip on Windows because temp directory drive may differ from configured ssh local path.",
+    )
     def test_get_job_from_remote_with_directories(self):
         import tempfile
 

--- a/tests/unit/base/test_remote_ssh_connection.py
+++ b/tests/unit/base/test_remote_ssh_connection.py
@@ -1,0 +1,485 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pysqa import QueueAdapter
+
+try:
+    import paramiko
+    from tqdm import tqdm
+    from pysqa.base.remote import get_transport
+
+    skip_remote_test = False
+except ImportError:
+    skip_remote_test = True
+
+
+class FakeSSH:
+    @staticmethod
+    def get_transport(*args, **kwargs):
+        return None
+
+
+def _new_remote(directory_name):
+    path = os.path.dirname(os.path.abspath(__file__))
+    return QueueAdapter(directory=os.path.join(path, "../../static", directory_name))
+
+
+@unittest.skipIf(
+    skip_remote_test,
+    "Either paramiko or tqdm are not installed, so the remote queue adapter tests are skipped.",
+)
+class TestGetTransport(unittest.TestCase):
+    """Pure unit tests for get_transport(), without any network access."""
+
+    def test_get_transport_returns_transport(self):
+        ssh = MagicMock()
+        ssh.get_transport.return_value = "a-transport"
+        self.assertEqual(get_transport(ssh=ssh), "a-transport")
+
+    def test_get_transport_raises_value_error_when_missing(self):
+        with self.assertRaises(ValueError):
+            get_transport(ssh=FakeSSH())
+
+
+@unittest.skipIf(
+    skip_remote_test,
+    "Either paramiko or tqdm are not installed, so the remote queue adapter tests are skipped.",
+)
+class TestOpenSSHConnection(unittest.TestCase):
+    """Unit tests for the authentication branches of _open_ssh_connection().
+
+    paramiko.SSHClient is mocked out entirely, so these tests never touch the
+    network - unlike the TestRemoteQueueAdapterRebex tests which connect to
+    test.rebex.net and therefore require network access plus a known_hosts
+    entry that matches the CI setup.
+    """
+
+    def test_key_with_passphrase(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_key_passphrase = "secret"
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_ssh.connect.assert_called_once_with(
+            hostname="hpc-cluster.university.edu",
+            port=22,
+            username="hpcuser",
+            key_filename=remote._adapter._ssh_key,
+            passphrase="secret",
+        )
+
+    def test_key_without_passphrase(self):
+        remote = _new_remote("remote")
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_ssh.connect.assert_called_once_with(
+            hostname="hpc-cluster.university.edu",
+            port=22,
+            username="hpcuser",
+            key_filename=remote._adapter._ssh_key,
+        )
+
+    def test_password_auth(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_key = None
+        remote._adapter._ssh_password = "test1234"
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_ssh.connect.assert_called_once_with(
+            hostname="hpc-cluster.university.edu",
+            port=22,
+            username="hpcuser",
+            password="test1234",
+            look_for_keys=False,
+        )
+
+    def test_ask_for_password(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_key = None
+        remote._adapter._ssh_password = None
+        remote._adapter._ssh_ask_for_password = True
+        with (
+            patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls,
+            patch(
+                "pysqa.base.remote.getpass.getpass", return_value="typed-password"
+            ) as mock_getpass,
+        ):
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_getpass.assert_called_once()
+        mock_ssh.connect.assert_called_once_with(
+            hostname="hpc-cluster.university.edu",
+            port=22,
+            username="hpcuser",
+            password="typed-password",
+        )
+
+    def test_two_factor_with_authenticator_service(self):
+        remote = _new_remote("remote_alternative")
+        self.assertTrue(remote._adapter._ssh_two_factor_authentication)
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_ssh.connect.assert_called_once_with(
+            hostname="hpc-cluster.university.edu",
+            port=22,
+            username="hpcuser",
+            password="test1234",
+        )
+        mock_ssh.get_transport.return_value.auth_interactive.assert_called_once()
+        _, kwargs = mock_ssh.get_transport.return_value.auth_interactive.call_args
+        self.assertEqual(kwargs["username"], "hpcuser")
+        self.assertEqual(kwargs["submethods"], "")
+        handler = kwargs["handler"]
+        self.assertTrue(callable(handler))
+
+        # The handler imports pyauthenticator lazily; stub it out since the
+        # real package needs the native zbar library, which is unrelated to
+        # what is being tested here (that the handler forwards the 2FA code).
+        import sys
+        import types
+
+        fake_module = types.ModuleType("pyauthenticator")
+        fake_module.get_two_factor_code = lambda service: "654321"
+        with patch.dict(sys.modules, {"pyauthenticator": fake_module}):
+            self.assertEqual(
+                handler("title", "instructions", ["Verification code: "]),
+                ["654321"],
+            )
+            self.assertEqual(handler("title", "instructions", []), [])
+
+    def test_two_factor_without_authenticator_service(self):
+        remote = _new_remote("remote_alternative")
+        remote._adapter._ssh_authenticator_service = None
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_ssh.get_transport.return_value.auth_interactive_dumb.assert_called_once_with(
+            username="hpcuser", handler=None, submethods=""
+        )
+
+    def test_ask_for_password_with_two_factor(self):
+        remote = _new_remote("remote_alternative")
+        remote._adapter._ssh_password = None
+        remote._adapter._ssh_authenticator_service = None
+        remote._adapter._ssh_ask_for_password = True
+        with (
+            patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls,
+            patch(
+                "pysqa.base.remote.getpass.getpass", return_value="typed-password"
+            ) as mock_getpass,
+        ):
+            mock_ssh = MagicMock()
+            mock_cls.return_value = mock_ssh
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_ssh)
+        mock_getpass.assert_called_once()
+        mock_ssh.connect.assert_called_once_with(
+            hostname="hpc-cluster.university.edu",
+            port=22,
+            username="hpcuser",
+            password="typed-password",
+        )
+        mock_ssh.get_transport.return_value.auth_interactive_dumb.assert_called_once_with(
+            username="hpcuser", handler=None, submethods=""
+        )
+
+    def test_proxy_host(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_key = None
+        remote._adapter._ssh_password = "test1234"
+        remote._adapter._ssh_proxy_host = "proxy.example.com"
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_client_new = MagicMock()
+            mock_cls.side_effect = [mock_ssh, mock_client_new]
+            result = remote._adapter._open_ssh_connection()
+        self.assertIs(result, mock_client_new)
+        self.assertIs(remote._adapter._ssh_proxy_connection, mock_ssh)
+        mock_ssh.get_transport.return_value.open_channel.assert_called_once_with(
+            kind="direct-tcpip",
+            dest_addr=("proxy.example.com", 22),
+            src_addr=("hpc-cluster.university.edu", 22),
+        )
+        mock_client_new.connect.assert_called_once_with(
+            hostname="proxy.example.com",
+            username="hpcuser",
+            sock=mock_ssh.get_transport.return_value.open_channel.return_value,
+        )
+
+    def test_proxy_host_raises_value_error_without_transport(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_key = None
+        remote._adapter._ssh_password = "test1234"
+        remote._adapter._ssh_proxy_host = "proxy.example.com"
+        with patch("pysqa.base.remote.paramiko.SSHClient") as mock_cls:
+            mock_ssh = MagicMock()
+            mock_ssh.get_transport.return_value = None
+            mock_cls.side_effect = [mock_ssh, MagicMock()]
+            with self.assertRaises(ValueError):
+                remote._adapter._open_ssh_connection()
+
+
+@unittest.skipIf(
+    skip_remote_test,
+    "Either paramiko or tqdm are not installed, so the remote queue adapter tests are skipped.",
+)
+class TestRemoteQueueAdapterMockedHelpers(unittest.TestCase):
+    """Unit tests for the remaining RemoteQueueAdapter helper methods, using
+    mocks instead of a live SSH connection."""
+
+    def test_transfer_files_raises_value_error_when_connection_is_none(self):
+        remote = _new_remote("remote")
+        with patch.object(remote._adapter, "_open_ssh_connection", return_value=None):
+            with self.assertRaises(ValueError):
+                remote._adapter._transfer_files(file_dict={"a": "b"})
+
+    def test_execute_remote_command_returns_empty_string_when_connection_is_none(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_continous_connection = False
+        with patch.object(remote._adapter, "_open_ssh_connection", return_value=None):
+            self.assertEqual(remote._adapter._execute_remote_command(command="pwd"), "")
+
+    def test_create_remote_dir_with_list(self):
+        remote = _new_remote("remote")
+        with patch.object(remote._adapter, "_execute_remote_command") as mock_execute:
+            remote._adapter._create_remote_dir(directory=["/a", "/b"])
+        mock_execute.assert_called_once_with(command="mkdir -p /a /b ")
+
+    def test_transfer_data_to_remote(self):
+        remote = _new_remote("remote")
+        # Use a real, non-empty directory so os.walk() actually visits files
+        # and exercises the directory/file bookkeeping loop.
+        local_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../../static/remote"
+        )
+        with (
+            patch.object(remote._adapter, "_create_remote_dir") as mock_create_dir,
+            patch.object(remote._adapter, "_transfer_files") as mock_transfer,
+        ):
+            remote._adapter._transfer_data_to_remote(working_directory=local_dir)
+        mock_create_dir.assert_called_once()
+        new_dir_list = mock_create_dir.call_args.kwargs["directory"]
+        self.assertEqual(len(new_dir_list), 1)
+        mock_transfer.assert_called_once()
+        file_dict = mock_transfer.call_args.kwargs["file_dict"]
+        self.assertIn(os.path.join(os.path.abspath(local_dir), "queue.yaml"), file_dict)
+
+    def test_del_closes_open_connections(self):
+        remote = _new_remote("remote")
+        mock_connection = MagicMock()
+        mock_proxy_connection = MagicMock()
+        remote._adapter._ssh_connection = mock_connection
+        remote._adapter._ssh_proxy_connection = mock_proxy_connection
+        remote._adapter.__del__()
+        mock_connection.close.assert_called_once()
+        mock_proxy_connection.close.assert_called_once()
+
+
+@unittest.skipIf(
+    skip_remote_test,
+    "Either paramiko or tqdm are not installed, so the remote queue adapter tests are skipped.",
+)
+class TestRemoteQueueAdapterPublicMethods(unittest.TestCase):
+    """Unit tests for the public RemoteQueueAdapter methods, with
+    _execute_remote_command mocked out so no SSH connection is required."""
+
+    def test_submit_job(self):
+        remote = _new_remote("remote")
+        with patch.object(
+            remote._adapter,
+            "_execute_remote_command",
+            return_value="Submitted batch job 42\n",
+        ) as mock_execute:
+            result = remote._adapter.submit_job(command="echo hello")
+        self.assertEqual(result, 42)
+        mock_execute.assert_called_once_with(command="echo hello")
+
+    def test_enable_reservation(self):
+        remote = _new_remote("remote")
+        with patch.object(
+            remote._adapter, "_execute_remote_command", return_value="ok\n"
+        ) as mock_execute:
+            result = remote._adapter.enable_reservation(process_id=42)
+        self.assertEqual(result, "ok\n")
+        mock_execute.assert_called_once_with(
+            command=remote._adapter._reservation_command(job_id=42)
+        )
+
+    def test_delete_job(self):
+        remote = _new_remote("remote")
+        with patch.object(
+            remote._adapter, "_execute_remote_command", return_value="ok\n"
+        ) as mock_execute:
+            result = remote._adapter.delete_job(process_id=42)
+        self.assertEqual(result, "ok\n")
+        mock_execute.assert_called_once_with(
+            command=remote._adapter._delete_command(job_id=42)
+        )
+
+    def test_get_queue_status(self):
+        remote = _new_remote("remote")
+        status_json = (
+            '{"jobid": [1, 2], "user": ["janj", "maxi"], "status": '
+            '["running", "pending"]}'
+        )
+        with patch.object(
+            remote._adapter, "_execute_remote_command", return_value=status_json
+        ):
+            df = remote._adapter.get_queue_status()
+            self.assertEqual(len(df), 2)
+            df_filtered = remote._adapter.get_queue_status(user="janj")
+        self.assertEqual(list(df_filtered["jobid"]), [1])
+
+    def test_get_job_from_remote_with_directories(self):
+        import tempfile
+
+        remote = _new_remote("remote")
+        remote._adapter._ssh_delete_file_on_remote = True
+        with tempfile.TemporaryDirectory() as local_working_directory:
+            remote_working_directory = remote._adapter._get_remote_working_dir(
+                working_directory=local_working_directory
+            )
+            with (
+                patch.object(
+                    remote._adapter,
+                    "_execute_remote_command",
+                    return_value=(
+                        '{"dirs": ["'
+                        + remote_working_directory
+                        + '/subdir"], "files": ["out.txt"]}'
+                    ),
+                ) as mock_execute,
+                patch.object(remote._adapter, "_transfer_files") as mock_transfer,
+            ):
+                remote._adapter.get_job_from_remote(
+                    working_directory=local_working_directory
+                )
+            self.assertTrue(
+                os.path.isdir(os.path.join(local_working_directory, "subdir"))
+            )
+            self.assertEqual(mock_transfer.call_count, 1)
+            self.assertEqual(mock_execute.call_count, 2)
+
+    def test_transfer_file(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_delete_file_on_remote = True
+        with (
+            patch.object(remote._adapter, "_create_remote_dir") as mock_create_dir,
+            patch.object(remote._adapter, "_transfer_files") as mock_transfer,
+            patch.object(remote._adapter, "_execute_remote_command") as mock_execute,
+        ):
+            remote._adapter.transfer_file(
+                file="readme.txt", transfer_back=True, delete_file_on_remote=True
+            )
+        mock_create_dir.assert_called_once()
+        mock_transfer.assert_called_once()
+        mock_execute.assert_called_once()
+
+    def test_transfer_file_no_delete(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_delete_file_on_remote = True
+        with (
+            patch.object(remote._adapter, "_create_remote_dir"),
+            patch.object(remote._adapter, "_transfer_files"),
+            patch.object(remote._adapter, "_execute_remote_command") as mock_execute,
+        ):
+            remote._adapter.transfer_file(file="readme.txt", transfer_back=False)
+        mock_execute.assert_not_called()
+
+
+@unittest.skipIf(
+    skip_remote_test,
+    "Either paramiko or tqdm are not installed, so the remote queue adapter tests are skipped.",
+)
+class TestTransferFilesSftp(unittest.TestCase):
+    """Unit tests for the SFTP transfer loop in _transfer_files(), with the
+    SSH connection mocked out."""
+
+    def test_transfer_files_put(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_continous_connection = False
+        mock_sftp = MagicMock()
+        mock_ssh = MagicMock()
+        mock_ssh.open_sftp.return_value = mock_sftp
+        with patch.object(
+            remote._adapter, "_open_ssh_connection", return_value=mock_ssh
+        ):
+            remote._adapter._transfer_files(
+                file_dict={"local.txt": "remote.txt"}, transfer_back=False
+            )
+        mock_sftp.put.assert_called_once_with("local.txt", "remote.txt")
+        mock_sftp.close.assert_called_once()
+
+    def test_transfer_files_get_existing_file(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_continous_connection = False
+        mock_sftp = MagicMock()
+        mock_ssh = MagicMock()
+        mock_ssh.open_sftp.return_value = mock_sftp
+        with patch.object(
+            remote._adapter, "_open_ssh_connection", return_value=mock_ssh
+        ):
+            remote._adapter._transfer_files(
+                file_dict={"local.txt": "remote.txt"}, transfer_back=True
+            )
+        mock_sftp.stat.assert_called_once_with("remote.txt")
+        mock_sftp.get.assert_called_once_with("remote.txt", "local.txt")
+
+    def test_transfer_files_get_missing_file_is_ignored(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_continous_connection = False
+        mock_sftp = MagicMock()
+        mock_sftp.stat.side_effect = FileNotFoundError
+        mock_ssh = MagicMock()
+        mock_ssh.open_sftp.return_value = mock_sftp
+        with patch.object(
+            remote._adapter, "_open_ssh_connection", return_value=mock_ssh
+        ):
+            remote._adapter._transfer_files(
+                file_dict={"local.txt": "remote.txt"}, transfer_back=True
+            )
+        mock_sftp.get.assert_not_called()
+
+    def test_transfer_files_with_provided_sftp_does_not_open_connection(self):
+        remote = _new_remote("remote")
+        mock_sftp = MagicMock()
+        with patch.object(remote._adapter, "_open_ssh_connection") as mock_open:
+            remote._adapter._transfer_files(
+                file_dict={"local.txt": "remote.txt"},
+                sftp=mock_sftp,
+                transfer_back=False,
+            )
+        mock_open.assert_not_called()
+        mock_sftp.put.assert_called_once_with("local.txt", "remote.txt")
+        mock_sftp.close.assert_not_called()
+
+    def test_transfer_files_continuous_connection(self):
+        remote = _new_remote("remote")
+        remote._adapter._ssh_continous_connection = True
+        mock_sftp = MagicMock()
+        mock_ssh = MagicMock()
+        mock_ssh.open_sftp.return_value = mock_sftp
+        with patch.object(
+            remote._adapter, "_open_ssh_connection", return_value=mock_ssh
+        ) as mock_open:
+            remote._adapter._transfer_files(
+                file_dict={"local.txt": "remote.txt"}, transfer_back=False
+            )
+        mock_open.assert_called_once()
+        self.assertIs(remote._adapter._ssh_connection, mock_ssh)

--- a/tests/unit/base/test_validate.py
+++ b/tests/unit/base/test_validate.py
@@ -1,5 +1,9 @@
 import unittest
-from pysqa.base.validate import value_error_if_none, value_in_range, check_queue_parameters
+from pysqa.base.validate import (
+    value_error_if_none,
+    value_in_range,
+    check_queue_parameters,
+)
 
 
 class TestValidate(unittest.TestCase):
@@ -37,9 +41,19 @@ class TestValidate(unittest.TestCase):
             "60G",
         )
 
+    def test_memory_string_comparison_non_memory_strings(self):
+        # "5x"/"3y"/"9z" contain a digit but are not valid memory specs, so
+        # _memory_spec_string_to_value() returns them unchanged (line 149).
+        self.assertEqual(value_in_range("5x", value_min="3y", value_max="9z"), "5x")
+
     def test_check_queue_parameters(self):
         cores, run_time_max, memory_max = check_queue_parameters(
-            active_queue={"cores_min": 1, "cores_max": 100, "memory_max": 12, "run_time_max": 1000},
+            active_queue={
+                "cores_min": 1,
+                "cores_max": 100,
+                "memory_max": 12,
+                "run_time_max": 1000,
+            },
             cores=1,
             run_time_max=100,
             memory_max=10,

--- a/tests/unit/test_queueadapter.py
+++ b/tests/unit/test_queueadapter.py
@@ -37,6 +37,24 @@ class TestQueueAdapter(unittest.TestCase):
             QueueAdapter(directory=os.path.join(self.path, "../static/bad_template"))
 
 
+class TestQueueAdapterDelegation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path = os.path.dirname(os.path.abspath(__file__))
+        cls.slurm = QueueAdapter(directory=os.path.join(cls.path, "../static/slurm"))
+
+    def test_get_job_from_remote_delegates_to_adapter(self):
+        # QueueAdapterWithConfig (used for non-REMOTE queue types) does not
+        # implement get_job_from_remote, so the call is delegated and then
+        # raises NotImplementedError.
+        with self.assertRaises(NotImplementedError):
+            self.slurm.get_job_from_remote(working_directory=".")
+
+    def test_transfer_file_to_remote_delegates_to_adapter(self):
+        with self.assertRaises(NotImplementedError):
+            self.slurm.transfer_file_to_remote(file="test.py")
+
+
 @unittest.skipIf(
     skip_multi_test,
     "Either paramiko or tqdm are not installed, so the multi queue adapter tests are skipped.",
@@ -57,13 +75,13 @@ class TestMultiQueueAdapter(unittest.TestCase):
         self.assertEqual(self.multi.list_clusters(), ["local_slurm", "remote_slurm"])
 
     def test_switch_cluster(self):
-        self.assertEqual(self.multi.queue_list, ['slurm'])
+        self.assertEqual(self.multi.queue_list, ["slurm"])
         self.multi.switch_cluster("local_slurm")
-        self.assertEqual(self.multi.queue_list, ['slurm'])
+        self.assertEqual(self.multi.queue_list, ["slurm"])
         self.multi.switch_cluster("remote_slurm")
-        self.assertEqual(self.multi.queue_list, ['remote'])
+        self.assertEqual(self.multi.queue_list, ["remote"])
         self.multi.switch_cluster("local_slurm")
-        self.assertEqual(self.multi.queue_list, ['slurm'])
+        self.assertEqual(self.multi.queue_list, ["slurm"])
 
 
 @unittest.skipIf(

--- a/tests/unit/wrapper/test_abstract.py
+++ b/tests/unit/wrapper/test_abstract.py
@@ -20,11 +20,11 @@ class TestAbstractSchedulerCommands(unittest.TestCase):
         self.assertIsNone(SchedulerCommands().submit_job_command)
 
     @patch.multiple(SchedulerCommands, __abstractmethods__=set())
-    def test_submit_job_command(self):
+    def test_delete_job_command(self):
         self.assertIsNone(SchedulerCommands().delete_job_command)
 
     @patch.multiple(SchedulerCommands, __abstractmethods__=set())
-    def test_submit_job_command(self):
+    def test_get_queue_status_command(self):
         self.assertIsNone(SchedulerCommands().get_queue_status_command)
 
 

--- a/tests/unit/wrapper/test_lsf.py
+++ b/tests/unit/wrapper/test_lsf.py
@@ -53,8 +53,18 @@ class TestLsfQueueAdapter(unittest.TestCase):
                 "here",
             )
 
+    def test_get_job_id_from_output(self):
+        self.assertEqual(
+            self.lsf._adapter._commands.get_job_id_from_output(
+                "Job <5136563> is submitted to default queue <normal>."
+            ),
+            5136563,
+        )
+
     def test_convert_queue_status_sge(self):
-        with open(os.path.join(self.path, "../../static/lsf", "bjobs_output"), "r") as f:
+        with open(
+            os.path.join(self.path, "../../static/lsf", "bjobs_output"), "r"
+        ) as f:
             content = f.read()
         df = pandas.DataFrame(
             {

--- a/tests/unit/wrapper/test_sge.py
+++ b/tests/unit/wrapper/test_sge.py
@@ -103,6 +103,12 @@ class TestSGEQueueAdapter(unittest.TestCase):
                 "here",
             )
 
+    def test_get_job_id_from_output(self):
+        self.assertEqual(
+            self.sge._adapter._commands.get_job_id_from_output("2836045.somehost"),
+            2836045,
+        )
+
     def test_convert_queue_status_sge(self):
         with open(os.path.join(self.path, "../../static/sge", "qstat.xml"), "r") as f:
             content = f.read()

--- a/tests/unit/wrapper/test_torque.py
+++ b/tests/unit/wrapper/test_torque.py
@@ -8,7 +8,9 @@ class TestTorqueQueueAdapter(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.path = os.path.dirname(os.path.abspath(__file__))
-        cls.torque = QueueAdapter(directory=os.path.join(cls.path, "../../static/torque"))
+        cls.torque = QueueAdapter(
+            directory=os.path.join(cls.path, "../../static/torque")
+        )
 
     def test_config(self):
         self.assertEqual(self.torque.config["queue_type"], "TORQUE")
@@ -40,6 +42,14 @@ class TestTorqueQueueAdapter(unittest.TestCase):
                 [],
                 "here",
             )
+
+    def test_get_job_id_from_output(self):
+        self.assertEqual(
+            self.torque._adapter._commands.get_job_id_from_output(
+                "80005196.somehost\n"
+            ),
+            80005196,
+        )
 
     def test_convert_queue_status_torque(self):
         with open(
@@ -79,4 +89,9 @@ class TestTorqueQueueAdapter(unittest.TestCase):
 #PBS -l wd
  
 echo hello"""
-        self.assertEqual(self.torque._adapter._commands.render_submission_template(command="echo hello"), output_str)
+        self.assertEqual(
+            self.torque._adapter._commands.render_submission_template(
+                command="echo hello"
+            ),
+            output_str,
+        )


### PR DESCRIPTION
## Summary
- Adds unit tests covering previously-untested code paths: the `REMOTE`/no-commands branches of `QueueAdapterCore` and `ModularQueueAdapter`, the CLI's `--delete`/`--reservation` error paths, `get_job_id_from_output` for the LSF/SGE/Torque wrappers, and the full set of `RemoteQueueAdapter` SSH authentication branches (key, password, ask-for-password, two-factor, proxy host) — all mocked via `paramiko.SSHClient` so they run without network access, unlike the existing `test.rebex.net`-based tests.
- Raises `src/pysqa` line coverage from 87% to 96% (measured locally with `pytest --cov`). The only remaining gaps are `wrapper/flux.py` (requires the real `flux-core` scheduler, already exercised by a separate CI job) and the `__main__` entry-point shim.
- Fixes three bugs uncovered while writing these tests:
  - `QueueAdapterCore.__init__` never set `self._submission_template` for queue types with no associated commands module (e.g. `"REMOTE"`), causing an `AttributeError` instead of the intended graceful no-op.
  - `ModularQueueAdapter`'s cluster-validation error called `.keys()` on `config["cluster"]`, which is actually a plain list per the config schema — so the intended `ValueError` crashed with an `AttributeError` instead.
  - Three test methods in `tests/unit/wrapper/test_abstract.py` shared the name `test_submit_job_command`; Python silently dropped two of them, so `wrapper/abstract.py` lines 29/40 were never actually exercised. Renamed them so all three run.

## Test plan
- [x] `pytest tests/unit` — 200 passed, 7 skipped (flux/sge optional deps), 8 pre-existing failures unrelated to this change (network-dependent `test.rebex.net` tests that need a CI-provisioned `known_hosts` entry)
- [x] `pytest tests/unit --cov=pysqa --cov-report=term-missing` — 96% coverage
- [x] `ruff check .` and `ruff format --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue adapter handling when no scheduler module is available, avoiding missing fallback behavior.
  * Updated cluster-missing error messaging to show clearer available cluster information.
  * Refined job submission parsing and status handling across supported queue types for more reliable results.
  * Added coverage for remote queue behavior, SSH connections, file transfers, reservations, and command-line validation to reduce regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->