### PR TITLE
[Documentation] Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ as well as the [command line interface](https://pysqa.readthedocs.io/en/latest/c
 
 ## Features
 The core feature of `pysqa` is the communication to HPC queuing systems including ([Flux](https://pysqa.readthedocs.io/en/latest/queue.html#flux), 
-[LFS](https://pysqa.readthedocs.io/en/latest/queue.html#lfs), [MOAB](https://pysqa.readthedocs.io/en/latest/queue.html#moab), 
+[LSF](https://pysqa.readthedocs.io/en/latest/queue.html#lsf), [MOAB](https://pysqa.readthedocs.io/en/latest/queue.html#moab), 
 [SGE](https://pysqa.readthedocs.io/en/latest/queue.html#sge), [SLURM](https://pysqa.readthedocs.io/en/latest/queue.html#slurm) 
 and [TORQUE](https://pysqa.readthedocs.io/en/latest/queue.html#torque)). This includes: 
 
@@ -53,7 +53,7 @@ from within `pysqa`, which are represented to the user as a single resource.
   * [conda-based installation](https://pysqa.readthedocs.io/en/latest/installation.html#conda-based-installation)
 * [Queuing Systems](https://pysqa.readthedocs.io/en/latest/queue.html)
   * [Flux](https://pysqa.readthedocs.io/en/latest/queue.html#flux)
-  * [LFS](https://pysqa.readthedocs.io/en/latest/queue.html#lfs)
+  * [LSF]](https://pysqa.readthedocs.io/en/latest/queue.html#lsf)
   * [MOAB](https://pysqa.readthedocs.io/en/latest/queue.html#moab)
   * [SGE](https://pysqa.readthedocs.io/en/latest/queue.html#sge)
   * [SLURM](https://pysqa.readthedocs.io/en/latest/queue.html#slurm)

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -60,8 +60,8 @@ In this case only the number of cores `cores`, the name of the job `job_name` , 
 `run_time_max` and the command `command` are communicated. The same template is stored in the `pysqa` package and can be
 imported using `from pysqa.wrapper.flux import template`. So the flux interface can be enabled by setting `queue_type="flux"`.
 
-## LFS
-For the load sharing facility framework from IBM the `queue.yaml` file defines the `queue_type` as `LSF`:
+## LSF
+For the Load Sharing Facility(LSF) framework from IBM the `queue.yaml` file defines the `queue_type` as `LSF`:
 ```
 queue_type: LSF
 queue_primary: lsf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the queue-system name from “LFS” to “LSF” across the documentation.
  * Clarified that LSF refers to IBM’s Load Sharing Facility.
  * Updated the documentation link in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->