### PR TITLE
Add copyright year to configuration file

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
 title: pysqa
 author: Jan Janssen
+copyright: "2026"
 
 execute:
   execute_notebooks           : off


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Jupyter Book copyright year to 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->