### PR TITLE
Fix the Python interface documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ using the built-in functionality of the queuing system. Finally, `pysqa` enables
 using SSH including support for two factor authentication via [pyauthenticator](https://github.com/jan-janssen/pyauthenticator), 
 this allows the users to submit task from a python process on their local workstation to remote HPC clusters.
 
-All this functionality is available from both the [Python interface](https://pysqa.readthedocs.io/en/latest/example.html) 
+All this functionality is available from both the [Python interface](https://pysqa.readthedocs.io/en/latest/example_queue_type.html) 
 as well as the [command line interface](https://pysqa.readthedocs.io/en/latest/command.html). 
 
 ## Features


### PR DESCRIPTION
The README links the "Python interface" to `https://pysqa.readthedocs.io/en/latest/example.html`, which returns 404. There is no `example` page in `docs/_toc.yml`; the Python interface walkthrough is `notebooks/example_queue_type.ipynb`, titled "Dynamic Python Interface".

Repointed the link to `example_queue_type.html`.

Verified by requesting every page in `docs/_toc.yml`: `example.html` is the only 404, and `example_queue_type.html` returns 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README link to point to the renamed Python interface documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->